### PR TITLE
Fix Lockr.prefix() Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ or maybe download it manually from [here](https://raw.github.com/tsironis/lockr/
 *Example*
 
 ```js
-Lockr.prefix = 'lockr';
+Lockr.prefix = 'lockr_';
 Lockr.set('username', 'Coyote'); // Saved as string
 localStorage.getItem('username');
 > null


### PR DESCRIPTION
Fixes #55

The documentation states that prefix will be prefixed to the key. In the example an underscore has been inserted which does not reflect the actual behavior of the function. This change will solve this confusion.